### PR TITLE
Fix race condition with PasswordCredential

### DIFF
--- a/static/scripts/app.js
+++ b/static/scripts/app.js
@@ -184,17 +184,21 @@ app.onPwSignIn = function(e) {
   // Polymer `iron-form` feature to validate the form
   if (!signinForm.validate()) return;
 
-  let form = new FormData(signinForm);
+  let signinFormData = new FormData(signinForm);
 
+  // Store the exact credentials sent to the server
+  let email = signinFormData.get('email');
+  let password = signinFormData.get('password');
+  
   // Sign-In with our own server
-  app._fetch(PASSWORD_LOGIN, form)
+  app._fetch(PASSWORD_LOGIN, signinFormData)
   .then(app.signedIn)
   .then(profile => {
     app.$.dialog.close();
 
     if (app.cmaEnabled) {
       // Construct `FormData` object from actual `form`
-      let cred = new PasswordCredential(signinForm);
+      let cred = new PasswordCredential({id: email, password: password});
       cred.name = profile.name;
 
       // Store credential information before posting
@@ -348,8 +352,14 @@ app.onRegister = function(e) {
 
   // Polymer `iron-form` feature to validate the form
   if (!regForm.validate()) return;
+  
+  let regFormData = new FormData(regForm);
+  
+  // Store the exact credentials sent to the server
+  let email = regFormData.get('email');
+  let password = regFormData.get('password');
 
-  app._fetch(REGISTER, new FormData(regForm))
+  app._fetch(REGISTER, regFormData)
   .then(app.signedIn)
   .then(profile => {
     app.fire('show-toast', {
@@ -358,7 +368,7 @@ app.onRegister = function(e) {
 
     if (app.cmaEnabled) {
       // Create password credential
-      let cred = new PasswordCredential(regForm);
+      let cred = new PasswordCredential({id: email, password: password});
       cred.name = profile.name;
       cred.iconURL = profile.imageUrl;
 


### PR DESCRIPTION
There's a somewhat large race condition in the sample code. Currently the password credentials are pulled from the form *after* successfully submitting the form to the server. On slow or flaky connections this provides plenty of time for the user to accidentally (or intentionally) change one of the fields on the form. If this happens then the credentials saved as "valid" aren't valid at all.

Replication and verification of the issue can be done easily by adding a network throttle in the Chrome Dev tools, using a custom one with a long delay (e.g. 5 seconds) and then editing one of the two credential fields after registering for a new account in the sample (although, network throttling looks broken in Canary currently, even setting it to offline has no effect). The credentials will be saved successfully but no future auto-logins will succeed because the saved credentials are not correct.

The larger issue is that the spec encourages developers to the pattern that was already in the sample code, since one of the two constructors for `PasswordCredential` is a `HTMLFormElement` which means providing the form element itself, which is vulnerable to this race-condition.